### PR TITLE
Updated references to newest 1.2.x version of Apache Storm

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 # Overview
 SpamScope is an advanced spam analysis tool that use [Apache Storm](http://storm.apache.org/) with [streamparse](https://github.com/Parsely/streamparse) to process a stream of mails.
 To understand how SpamScope works, I suggest to read these overviews:
- - [Apache Storm Concepts](http://storm.apache.org/releases/1.2.1/Concepts.html)
+ - [Apache Storm Concepts](http://storm.apache.org/releases/1.2.3/Concepts.html)
  - [Streamparse Quickstart](http://streamparse.readthedocs.io/en/stable/quickstart.html)
 
 In general the first step is run Apache Storm, then you can run the topologies on it.

--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ Storm <http://storm.apache.org/>`__ with
 `streamparse <https://github.com/Parsely/streamparse>`__ to process a
 stream of mails. To understand how SpamScope works, I suggest to read
 these overviews: - `Apache Storm
-Concepts <http://storm.apache.org/releases/1.2.1/Concepts.html>`__ -
+Concepts <http://storm.apache.org/releases/1.2.3/Concepts.html>`__ -
 `Streamparse
 Quickstart <http://streamparse.readthedocs.io/en/stable/quickstart.html>`__
 

--- a/ansible/hosts
+++ b/ansible/hosts
@@ -6,8 +6,8 @@ bin_path="/usr/local/bin"
 install_path="/opt"
 
 # Apache Storm
-distro_name="apache-storm-1.2.1"
-apache_storm_mirror="http://it.apache.contactlab.it/storm"
+distro_name="apache-storm-1.2.3"
+apache_storm_mirror="https://downloads.apache.org/storm"
 file_distro_name="{{ distro_name }}.tar.gz"
 storm_url="{{ apache_storm_mirror }}/{{ distro_name }}/{{ file_distro_name }}"
 delay=30


### PR DESCRIPTION
Apache Storm version 1.2.1 is not available anymore, neither on the main Apache download source nor on the mirrors (see: https://downloads.apache.org/storm/). Updated the reference in the READMEs (broken link) as well as in the Ansible variables.

Also, the provided mirror http://it.apache.contactlab.it/storm is currently not reachable (seems dead). Replaced it with the main Apache download URL.